### PR TITLE
WSL-init: set mount propagation to slave.

### DIFF
--- a/files/wsl-init
+++ b/files/wsl-init
@@ -15,7 +15,7 @@ if [ $$ -ne "1" ]; then
     # This is not running as PID 1; this means that this is a normal invocation
     # from WSL.  Set up the namespaces, and try again.
     echo $$ > /run/wsl-init.pid
-    exec /usr/bin/unshare --pid --mount-proc --fork --propagation private "${0}"
+    exec /usr/bin/unshare --pid --mount-proc --fork --propagation slave "${0}"
 fi
 
 # Mark directories that we will need to bind mount as shared mounts.


### PR DESCRIPTION
When running containers with mounts, we need to be able to create new mounts (in the root WSL namespace) that propagate into the mount namespace containing dockerd.  This means we need slave propagation rather than private (so it's one-way).

This is part of the fix for https://github.com/rancher-sandbox/rancher-desktop/issues/1077.