### PR TITLE
wsl.conf: enable `metadata` mount option (compat).

### DIFF
--- a/files/wsl.conf
+++ b/files/wsl.conf
@@ -3,3 +3,5 @@
 # Prevent processing /etc/fstab, since it doesn't exist.
 mountFsTab = false
 ldconfig = false
+# Needed for compatibility with some `npm install` scenarios.
+options = metadata


### PR DESCRIPTION
Turn on the "metadata" mount option for drvfs (/mnt/c/ etc.).  This is required for compatibility with some workloads, as they otherwise get EPERM even though the mount should be world writable.

See also: https://github.com/rancher-sandbox/rancher-desktop/issues/1077