### PR TITLE
Stop generating /etc/hosts and /etc/resolv.conf + install dnsmasq

### DIFF
--- a/files/build.sh
+++ b/files/build.sh
@@ -61,6 +61,11 @@ tar -xvf /nerdctl.tgz -C /distro/usr/local/ \
 # Add packages required for nerdctl
 apk --root /distro add iptables ip6tables
 
+# Add dnsmasq
+apk --root /distro add dnsmasq
+mkdir -p /distro/var/lib/misc
+chroot /distro /sbin/rc-update add dnsmasq default
+
 # Add guest agent
 install rancher-desktop-guestagent /distro/usr/local/bin
 install rancher-desktop-guestagent.initd /distro/etc/init.d/rancher-desktop-guestagent

--- a/files/wsl.conf
+++ b/files/wsl.conf
@@ -5,3 +5,8 @@ mountFsTab = false
 ldconfig = false
 # Needed for compatibility with some `npm install` scenarios.
 options = metadata
+
+[network]
+# Rather than generate automatically, we copy it over from the data distribution
+# while adding the *.internal hosts.
+generateHosts = false

--- a/files/wsl.conf
+++ b/files/wsl.conf
@@ -10,3 +10,5 @@ options = metadata
 # Rather than generate automatically, we copy it over from the data distribution
 # while adding the *.internal hosts.
 generateHosts = false
+# Disable generating /etc/resolv.conf too; we'll use a local dnsmasq instead.
+generateResolvConf = false


### PR DESCRIPTION
In order to support `host.docker.internal` and `host.minikube.internal` (and any other DNS names we choose to) for https://github.com/rancher-sandbox/rancher-desktop/issues/893, we should stop generating `/etc/hosts` and `/etc/resolv.conf`, and install dnsmasq.  This way we can run a local DNS forwarder.