### PR TITLE
Add sudo command to distro

### DIFF
--- a/files/build.sh
+++ b/files/build.sh
@@ -89,6 +89,7 @@ ln -s /run /distro/var/run
 
 apk --root /distro add apk-tools
 apk --root /distro add curl
+apk --root /distro add sudo
 
 # Clean up apk metadata and other unneeded files
 rm -rf /distro/var/cache/apk


### PR DESCRIPTION
It is not really needed, as everything already runs as root, but having the binary allows us to use `rdctl shell sudo ...` in
docs and integration tests, and not have to remove the `sudo` part on Windows.
