### PR TITLE
Add containerd-ctr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine as builder
+ARG ALPINE_VERSION=3.18
+FROM alpine:${ALPINE_VERSION} as builder
 
 ARG BUILD_ID=
 ARG VERSION_ID=0.4

--- a/files/build.sh
+++ b/files/build.sh
@@ -100,6 +100,7 @@ apk --root /distro add sudo
 apk --root /distro add git # so docker-compose can use a git URL
 apk --root /distro add zstd # because `docker load` doesn't support .tar.zst files
 apk --root /distro add tar # because `nerdctl cp` needs GNU tar
+apk --root /distro add containerd-ctr # needed to copy files to the host
 
 # mkcert is used by the image-allow-list feature
 apk --root /distro add mkcert --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing


### PR DESCRIPTION
This is needed to implement copying files out of images for nerdctl.

Also pin the alpine image to 3.18 (to ensure we don't attempt to build with an older version).

This is the equivalent of https://github.com/rancher-sandbox/alpine-lima/pull/13.