### PR TITLE
Add tini to the distro

### DIFF
--- a/files/build.sh
+++ b/files/build.sh
@@ -67,6 +67,7 @@ chmod 755 /distro/usr/local/bin/nerdctl
 
 # Add packages required for nerdctl
 apk --root /distro add iptables ip6tables
+apk --root /distro add tini
 
 # Add dnsmasq
 apk --root /distro add dnsmasq


### PR DESCRIPTION
`nerdctl run --init` and `nerdctl compose --init` need tini to run as the init process inside the container.

Needed for https://github.com/rancher-sandbox/rancher-desktop/issues/5150