### PR TITLE
We need tini-static for `nerdctl run --init`

### DIFF
--- a/files/build.sh
+++ b/files/build.sh
@@ -67,7 +67,8 @@ chmod 755 /distro/usr/local/bin/nerdctl
 
 # Add packages required for nerdctl
 apk --root /distro add iptables ip6tables
-apk --root /distro add tini
+apk --root /distro add tini-static
+ln -s /sbin/tini-static /distro/usr/bin/tini
 
 # Add dnsmasq
 apk --root /distro add dnsmasq


### PR DESCRIPTION
The regular `tini` binary is linked against musl, so won't work in non-Alpine containers.

  lima-std:~# ldd /sbin/tini
	/lib/ld-musl-x86_64.so.1 (0x7f32fea7c000)
	libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f32fea7c000)