### PR TITLE
Support iptables-legacy

### DIFF
--- a/files/build.sh
+++ b/files/build.sh
@@ -66,7 +66,7 @@ EOF
 chmod 755 /distro/usr/local/bin/nerdctl
 
 # Add packages required for nerdctl
-apk --root /distro add iptables ip6tables
+apk --root /distro add iptables ip6tables iptables-legacy
 apk --root /distro add tini-static
 ln -s /sbin/tini-static /distro/usr/bin/tini
 
@@ -109,6 +109,15 @@ apk --root /distro add mkcert --repository=http://dl-cdn.alpinelinux.org/alpine/
 
 # add openresty with http-proxy-connect module for the image-allow-list feature
 apk --root /distro add --allow-untrusted --force-non-repository /openresty/x86_64/*.apk
+
+# Override iptables to support older kernels
+cp /iptables-stub /distro/usr/local/bin/iptables-stub
+chmod a+x /distro/usr/local/bin/iptables-stub
+for family in iptables ip6tables; do
+  for suffix in '' -save -restore; do
+    ln -sfT /usr/local/bin/iptables-stub "/distro/sbin/${family}${suffix}"
+  done
+done
 
 # Clean up apk metadata and other unneeded files
 rm -rf /distro/var/cache/apk

--- a/files/iptables-stub
+++ b/files/iptables-stub
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# This is a script to dynamically select between nftables and iptables-legacy
+# depending on the kernel version.  This is necessary to support older versions
+# of WSL that runs kernel <5.15 (where nftables doesn't work).
+#
+# This works by figuring out the correct executable to use, and then bind
+# mounting the correct executable on top of this script (which doesn't persist
+# across reboot), before running the desired command again, this time using the
+# target executable.
+
+set -o errexit -o nounset
+
+version="$(uname -r)"
+major="${version%%.*}"
+minor="${version#*.}"
+minor="${minor%%.*}"
+
+# shellcheck disable=2166 # We only care about busybox; tested to work.
+if [ "$major" -lt 5 ] || [ "$major" -eq 5 -a "$minor" -lt 15 ]; then
+    mount --bind /sbin/xtables-legacy-multi /usr/local/bin/iptables-stub
+else
+    mount --bind /sbin/xtables-nft-multi /usr/local/bin/iptables-stub
+fi
+
+# Re-run this script, using the same name as originally invoked.
+exec "$0" "$@"


### PR DESCRIPTION
We upgrade to alpine 3.19 in #83, where iptables has switched to defaulting to the nftables backend.  This does not work in some WSL scenarios where the kernel is older than 5.15.

To work around this, install the `iptables-legacy` package, and replace `/sbin/ip{,6}tables{,-save,-restore}` with a shell script that detects the kernel version and arranges for the correct backend to be called.

Tested on both up-to-date kernel and legacy (pre-5.15) kernel.  Note that the latter will need changes in Rancher Desktop to disable the unmet prerequisites dialog.