### PR TITLE
Bump RD networking v1.2.2 -> v1.2.3

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -3,7 +3,7 @@
 # be set to be automatically updated.
 
 RD_NETWORKING_REPO=rancher-sandbox/rancher-desktop-networking
-RD_NETWORKING_VERSION=v1.2.2
+RD_NETWORKING_VERSION=v1.2.3
 NERDCTL_REPO=containerd/nerdctl
 NERDCTL_VERSION=v1.7.5
 OPENRESTY_REPO=rancher-sandbox/openresty-packaging


### PR DESCRIPTION
Bumps Rancher Desktop Networking to v1.2.3.