### PR TITLE
CI: Make dependencies workflow use custom tokens

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -9,13 +9,14 @@ concurrency:
   group: ${{ github.workflow }}:${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write # For rancher-eio/read-value-secrets
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -24,8 +25,31 @@ jobs:
         sudo wget -O /usr/local/bin/semver \
           https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.4.0/src/semver
         sudo chmod a+x /usr/local/bin/semver
+    - run: echo "GH_TOKEN=${GH_TOKEN}" >> "$GITHUB_ENV"
+      if: github.repository_owner != 'rancher-sandbox'
+      env:
+        GH_TOKEN: ${{ secrets.RUN_WORKFLOW_FROM_WORKFLOW }}
+    - uses: rancher-eio/read-vault-secrets@main
+      if: github.repository_owner == 'rancher-sandbox'
+      with:
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
+          secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY
+    - uses: actions/create-github-app-token@v1
+      if: github.repository_owner == 'rancher-sandbox'
+      id: app-token
+      with:
+        app-id: ${{ env.APP_ID }}
+        private-key: ${{ env.PRIVATE_KEY }}
+    - name: Set GitHub token from vault
+      if: github.repository_owner == 'rancher-sandbox'
+      run: |
+        echo "GH_TOKEN=${GH_TOKEN}" >> "$GITHUB_ENV"
+        echo "APP_ID=" >> "$GITHUB_ENV"
+        echo "PRIVATE_KEY=" >> "$GITHUB_ENV"
+      env:
+        GH_TOKEN: "${{ steps.app-token.outputs.token }}"
     - run: bash .github/workflows/dependencies.sh
       env:
         GIT_AUTHOR_NAME: Rancher Desktop WSL Distro Depdency Updater
         GIT_AUTHOR_EMAIL: donotuse@rancherdesktop.io # See rddepman
-        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The workflow currently uses the token generated by the action to trigger pull requests; this doesn't work correctly because tokens provided to workflows cannot be used to trigger further workflows (in particular, the tests that are required for merging PRs).

Reference: https://github.com/rancherlabs/eio/issues/2172