### PR TITLE
.profile: Use busybox to run shell tools

### DIFF
--- a/files/profile
+++ b/files/profile
@@ -3,7 +3,7 @@
 # distribution interactively.
 
 if busybox [[ "$-" == "*i*" ]]; then
-    <<-EOF tr '\n' ' ' | fold -s >&2
+    <<-EOF busybox tr '\n' ' ' | busybox fold -s >&2
 	The ${WSL_DISTRO_NAME:-rancher-desktop} WSL distribution is not meant to be
 	used to run any applications interactively. It is an implementation detail
 	of Rancher Desktop. Please enable WSL integration in the Preferences to
@@ -11,8 +11,8 @@ if busybox [[ "$-" == "*i*" ]]; then
 	Alternatively, the tools are available in Windows (such as via Command
 	Prompt or PowerShell).
 	EOF
-    printf "\n\n" >&2
-    <<-'EOF' tr '\n' ' ' | fold -s >&2
+    busybox printf "\n\n" >&2
+    <<-'EOF' busybox tr '\n' ' ' | busybox fold -s >&2
 	For troubleshooting Rancher Desktop, please use `rdctl shell`.
 	EOF
     exit 0


### PR DESCRIPTION
The rancher-desktop-data distribution does not have the symlinks for tr and fold (printf is a shell built-in so that works).  Explicitly use the busybox to invoke everything so that they will exist.

Fixes: 96a4ed3189691c0b2e26cab4294d0db34a8c64f0

Output:
```
> wsl -d rancher-desktop
The rancher-desktop WSL distribution is not meant to be used to run any
applications interactively. It is an implementation detail of Rancher Desktop.
Please enable WSL integration in the Preferences to make the tools available in
WSL distributions you install separately. Alternatively, the tools are
available in Windows (such as via Command Prompt or PowerShell).

For troubleshooting Rancher Desktop, please use `rdctl shell`.
> wsl -d rancher-desktop-data
The rancher-desktop-data WSL distribution is not meant to be used to run any
applications interactively. It is an implementation detail of Rancher Desktop.
Please enable WSL integration in the Preferences to make the tools available in
WSL distributions you install separately. Alternatively, the tools are
available in Windows (such as via Command Prompt or PowerShell).

For troubleshooting Rancher Desktop, please use `rdctl shell`.
```