### PR TITLE
Remove redundant curl install

### DIFF
--- a/files/build.sh
+++ b/files/build.sh
@@ -99,7 +99,6 @@ install -d /distro/var/log
 ln -s /run /distro/var/run
 
 apk --root /distro add apk-tools
-apk --root /distro add curl
 apk --root /distro add sudo
 apk --root /distro add git # so docker-compose can use a git URL
 apk --root /distro add zstd # because `docker load` doesn't support .tar.zst files


### PR DESCRIPTION
An extra install step of curl was introduced  a long time back. Removing the statement should be harmless.

It might speed up the build process a tiny bit ;-). Let's see what the build and e2e says about this change.

Ref: https://github.com/rancher-sandbox/rancher-desktop-wsl-distro/commit/b3e73c35db8f944e04720dc45d99ebf6209dc312#commitcomment-185446612