### PR TITLE
Revert "Bump nerdctl 2.2.2 → 2.3.1"

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -3,7 +3,7 @@
 # be set to be automatically updated.
 
 NERDCTL_REPO=containerd/nerdctl
-NERDCTL_VERSION=v2.3.1
+NERDCTL_VERSION=v2.2.2
 OPENRESTY_REPO=rancher-sandbox/openresty-packaging
 OPENRESTY_VERSION=v0.0.7
 CRI_DOCKERD_REPO=Mirantis/cri-dockerd


### PR DESCRIPTION
This reverts commit a3b26754e90dcbc164184e303d62a072cf0b44cf.